### PR TITLE
使windows下可编译

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.10)
 
+set(CMAKE_SYSTEM_NAME Generic)
+set(CMAKE_SYSTEM_PROCESSOR ARM)
+
 project(stm32l4_demo LANGUAGES C CXX)
 
 # 更详细的编译信息


### PR DESCRIPTION
在 windows 环境下构建编译工程需要在 `project(stm32l4_demo LANGUAGES C CXX)` 前增加 `set(CMAKE_SYSTEM_NAME Generic)`。

`CMAKE_SYSTEM_NAME` 变量用于指定项目的目标操作系统名称，"Generic" 通常表示你不是针对特定的操作系统进行构建，而是希望以更通用或跨平台的方式构建项目，这通常用于编写可以在多个不同平台上编译和运行的代码。

否则链接时会出现以下报错：
```shell
[  2%] Linking C executable C:/Users/33110/Projects/stm32l4_demo/output/stm32l4_demo.elf.exe
c:/program files (x86)/gcc-arm-none-eabi-10.3-2021.10/bin/../lib/gcc/arm-none-eabi/10.3.1/../../../../arm-none-eabi/bin/ld.exe: unrecognized option '--major-image-version'
c:/program files (x86)/gcc-arm-none-eabi-10.3-2021.10/bin/../lib/gcc/arm-none-eabi/10.3.1/../../../../arm-none-eabi/bin/ld.exe: use the --help option for usage information
collect2.exe: error: ld returned 1 exit status
make[2]: *** [CMakeFiles/stm32l4_demo.elf.dir/build.make:764：C:/Users/33110/Projects/stm32l4_demo/output/stm32l4_demo.elf.exe] 错误 1
make[1]: *** [CMakeFiles/Makefile2:83：CMakeFiles/stm32l4_demo.elf.dir/all] 错误 2
make: *** [Makefile:91：all] 错误 2
```